### PR TITLE
Fix `--version` error in Helm Chart packaging step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
           # helm package
           helm package charts/dashboard \
             --app-version ${GITHUB_REF#*/v} \
-            --version${GITHUB_REF#*/v}
+            --version ${GITHUB_REF#*/v}
 
       - name: Publish the Helm Chart
         run: |-


### PR DESCRIPTION
Fix a missing space in the `--version` flag for packaging the Helm Chart on release.

## Checklist

Before raising or requesting a review of the pull request, please check and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests locally to check
- [ ] I have added tests that prove that any changes are effective and work correctly
- [ ] I have made corresponding changes, as needed, to the repository documentation
- [x] Each commit in, and this pull request, have meaningful subjects and bodies for context
- [x] I have added `release/...`, `type/...`, and `changes/...` labels, as needed, to this pull request
