### PR TITLE
Fix `webPort` reference in `Ingress` resource

### DIFF
--- a/charts/dashboard/templates/ingress.yaml
+++ b/charts/dashboard/templates/ingress.yaml
@@ -27,8 +27,8 @@ spec:
         {{- end }}
     {{- end }}
   {{- end }}
-  {{- $fullName := include "dashboard.fullname" . }}
-  {{- $svcPort := .Values.service.port }}
+  {{- $name := include "dashboard.fullname" . }}
+  {{- $webPort := .Values.service.webPort }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
@@ -39,9 +39,9 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ $fullName }}-frontend
+                name: {{ $name }}-frontend
                 port:
-                  number: {{ $svcPort }}
+                  number: {{ $webPort }}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Fix the `webPort` reference in the `Ingress` resource as the `web` port for `Ingress` was pointing at the old configuration and therefore no longer valid.

## Checklist

Before raising or requesting a review of the pull request, please check and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests locally to check
- [ ] I have added tests that prove that any changes are effective and work correctly
- [ ] I have made corresponding changes, as needed, to the repository documentation
- [x] Each commit in, and this pull request, have meaningful subjects and bodies for context
- [x] I have added `release/...`, `type/...`, and `changes/...` labels, as needed, to this pull request
