### PR TITLE
Restore `logger.Start()` setup due to missing values

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -59,16 +59,6 @@ var (
 	// closed.
 	shutdownMetrics = 5
 
-	// loggerConfig provides the application information which will be used for
-	// every log line to help provide context to all logs.
-	loggerConfig = &map[string]string{
-		"name":       Name,
-		"version":    Version,
-		"commit":     Commit,
-		"arch":       Architecture,
-		"build-date": BuildDate,
-	}
-
 	// serveCmd represents the serve command for the dashboard application, and will
 	// provide the setup and arguments needed for the application to start the web
 	// service and start processing events.
@@ -152,7 +142,13 @@ func runServe(_ *cobra.Command, _ []string) error {
 	}
 
 	gin.SetMode(gin.ReleaseMode)
-	logger.Start(loggerConfig)
+	logger.Start(&map[string]string{
+		"name":       Name,
+		"version":    Version,
+		"commit":     Commit,
+		"arch":       Architecture,
+		"build-date": BuildDate,
+	})
 
 	// Create a context that listens for the interrupt signal from the Operating
 	// System so we can capture it and then trigger a graceful shutdown


### PR DESCRIPTION
Restore the `logger.Start()` setup as the `map` was not populating and the application build-time information was not being provided correctly.

## Checklist

Before raising or requesting a review of the pull request, please check and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests locally to check
- [ ] I have added tests that prove that any changes are effective and work correctly
- [ ] I have made corresponding changes, as needed, to the repository documentation
- [x] Each commit in, and this pull request, have meaningful subjects and bodies for context
- [x] I have added `release/...`, `type/...`, and `changes/...` labels, as needed, to this pull request
