### PR TITLE
Refactor Prometheus Metrics

### DIFF
--- a/config/serve.yaml
+++ b/config/serve.yaml
@@ -11,4 +11,5 @@ endpoints:
 
 logging:
   json: true
+  metrics: false
   level: debug

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -124,6 +124,10 @@ func init() {
 	flags.Int("shutdown-timeout", shutdownTimeout, "Timeout (in seconds) to wait for requests to finish")
 	_ = viper.BindPFlag("endpoints.timeouts.shutdown", flags.Lookup("shutdown-timeout"))
 
+	viper.SetDefault("logging.metrics", false)
+	flags.Bool("log-metrics", false, "Set whether to log metrics port requests")
+	_ = viper.BindPFlag("logging.metrics", flags.Lookup("log-metrics"))
+
 	rootCmd.AddCommand(serveCmd)
 }
 

--- a/internal/serve/metrics/main.go
+++ b/internal/serve/metrics/main.go
@@ -28,7 +28,7 @@ func NewService() *Service {
 	router := gin.New()
 
 	router.Use(middleware.Logger())
-	router.Use(middleware.Prometheus())
+	router.Use(middleware.Prometheus("metrics"))
 	router.Use(gin.Recovery())
 
 	proxies := viper.GetStringSlice("endpoints.proxies")

--- a/internal/serve/metrics/main.go
+++ b/internal/serve/metrics/main.go
@@ -27,7 +27,10 @@ type Service struct {
 func NewService() *Service {
 	router := gin.New()
 
-	router.Use(middleware.Logger())
+	if viper.GetBool("logging.metrics") {
+		router.Use(middleware.Logger())
+	}
+
 	router.Use(middleware.Prometheus("metrics"))
 	router.Use(gin.Recovery())
 

--- a/internal/serve/middleware/logger.go
+++ b/internal/serve/middleware/logger.go
@@ -21,11 +21,6 @@ func Logger() gin.HandlerFunc {
 					http.StatusUnauthorized,
 					http.StatusNotFound,
 				),
-				// slogg.IgnorePath(
-				// 	"/alive",
-				// 	"/healthz",
-				// 	"/metrics",
-				// ),
 			},
 		},
 	)

--- a/internal/serve/middleware/metrics.go
+++ b/internal/serve/middleware/metrics.go
@@ -26,7 +26,7 @@ func NewMetrics(namespace string) *Metrics {
 				Name:      "request_duration_seconds",
 				Help:      "The latency of the HTTP requests.",
 				//nolint:mnd // these are the building blocks for buckets
-				Buckets: prometheus.ExponentialBuckets(0.005, 2, 10),
+				Buckets: prometheus.ExponentialBuckets(0.0005, 2, 12),
 			},
 			[]string{"service", "handler", "method", "path", "status"},
 		),

--- a/internal/serve/web/main.go
+++ b/internal/serve/web/main.go
@@ -25,7 +25,7 @@ func NewService() *Service {
 	router := gin.New()
 
 	router.Use(middleware.Logger())
-	router.Use(middleware.Prometheus())
+	router.Use(middleware.Prometheus("web"))
 	router.Use(gin.Recovery())
 
 	proxies := viper.GetStringSlice("endpoints.proxies")

--- a/schemas/serve.json
+++ b/schemas/serve.json
@@ -171,6 +171,9 @@
         "level": {
           "$ref": "#/$defs/logging-level"
         },
+        "metrics": {
+          "$ref": "#/$defs/logging-metrics"
+        },
         "json": {
           "$ref": "#/$defs/logging-json"
         }
@@ -181,9 +184,15 @@
       "type": "string",
       "enum": ["debug", "info", "warning", "error"]
     },
+    "logging-metrics": {
+      "description": "Set whether or not to log requests to the metrics port",
+      "type": "boolean",
+      "default": false
+    },
     "logging-json": {
       "description": "Set whether or not to use JSON-based structured logging",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     }
   },
   "type": "object",


### PR DESCRIPTION
Refactor the basic Prometheus metrics handling to:

- Allow a split between `web` and `metrics` endpoints, so general requests to the `/alive` and `/healthz` metrics in the metrics endpoint don't skew the metrics for the web endpoint.
- Add support for response time summary and quantiles on a per-service basis rather than per-method/path/status.
- Add support for response size metrics.
- Add support for counting in-flight metrics.

## Checklist

Before raising or requesting a review of the pull request, please check and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests locally to check
- [ ] I have added tests that prove that any changes are effective and work correctly
- [ ] I have made corresponding changes, as needed, to the repository documentation
- [x] Each commit in, and this pull request, have meaningful subjects and bodies for context
- [x] I have added `release/...`, `type/...`, and `changes/...` labels, as needed, to this pull request
