### PR TITLE
Fix the port name for the `readinessProbe`

### DIFF
--- a/charts/dashboard/templates/deployment.yaml
+++ b/charts/dashboard/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: metric
+              port: metrics
           {{-   with .Values.pod.probes.readiness }}
             periodSeconds: {{ .periodSeconds }}
             initialDelaySeconds: {{ .initialDelaySeconds }}


### PR DESCRIPTION
Fix the `port` name used for the `readinessProbe` on the Deployment resource as this was incorrect.

## Checklist

Before raising or requesting a review of the pull request, please check and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests locally to check
- [ ] I have added tests that prove that any changes are effective and work correctly
- [ ] I have made corresponding changes, as needed, to the repository documentation
- [x] Each commit in, and this pull request, have meaningful subjects and bodies for context
- [x] I have added `release/...`, `type/...`, and `changes/...` labels, as needed, to this pull request
