### PR TITLE
Update dashboard to use the Pod IP as listening address

### DIFF
--- a/charts/dashboard/templates/deployment.yaml
+++ b/charts/dashboard/templates/deployment.yaml
@@ -54,11 +54,15 @@ spec:
         - name: {{ .Chart.Name | quote }}
           image: "{{ .Values.pod.image.repository }}:{{ .Values.pod.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.pod.image.pullPolicy }}
+          env:
+            - name: DASHBOARD_ENDPOINTS_BIND_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           args:
             - serve
             - --log-level={{ .Values.pod.logging.level }}
             - --log-json={{ if .Values.pod.logging.json }}true{{ else }}false{{ end }}
-            - --address=0.0.0.0
             - --cluster-name={{ include "dashboard.fullname" . }}
             - --web-port={{ .Values.service.webPort }}
             - --metrics-port={{ .Values.service.metricsPort }}


### PR DESCRIPTION
Update the dashboard application to use the Pod IP as the listening address, which should help improve the data in the log files by allowing that address to be used instead of the generic `0.0.0.0`.

This is being done through the environment variable setting overrides using viper as it's easier than setting it via the command-line.

## Checklist

Before raising or requesting a review of the pull request, please check and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests locally to check
- [ ] I have added tests that prove that any changes are effective and work correctly
- [ ] I have made corresponding changes, as needed, to the repository documentation
- [x] Each commit in, and this pull request, have meaningful subjects and bodies for context
- [x] I have added `release/...`, `type/...`, and `changes/...` labels, as needed, to this pull request
