### PR TITLE
Add support for HTTPRoute resource in the Helm Chart

### DIFF
--- a/.github/workflows/go-integrations.yaml
+++ b/.github/workflows/go-integrations.yaml
@@ -20,6 +20,8 @@ jobs:
         version:
           - '1.22'
           - '1.23'
+          - '1.24'
+          - '1.25'
         platform:
           - ubuntu-latest
       fail-fast: false

--- a/.github/workflows/go-integrations.yaml
+++ b/.github/workflows/go-integrations.yaml
@@ -161,14 +161,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dashboard_linux_arm64
-          path: dist/dashboard_linux_arm64/
+          path: dist/dashboard_linux_arm64_v8.0/
           if-no-files-found: error
 
       - name: Upload darwin_arm64
         uses: actions/upload-artifact@v4
         with:
           name: dashboard_darwin_arm64
-          path: dist/dashboard_darwin_arm64/
+          path: dist/dashboard_darwin_arm64_v8.0/
           if-no-files-found: error
 
       - name: Upload windows_amd64_v3
@@ -182,7 +182,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dashboard_windows_arm64
-          path: dist/dashboard_windows_arm64/
+          path: dist/dashboard_windows_arm64_v8.0/
           if-no-files-found: error
 
       - name: Upload Metadata

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,6 +65,9 @@ linters:
     # Computes and checks the cyclomatic complexity of functions.
     # (replaced by cyclop)
     - gocyclo
+    # Check logger calls conform to a specific format (seems to have some issues
+    # around the use of structured logging currently)
+    - loggercheck
     # Nlreturn checks for a new line before return and branch statements to
     # increase code clarity
     # (this is better managed by wsl)
@@ -80,8 +83,7 @@ linters:
     - wrapcheck
 
     ## Deprecated
-    - execinquery
-    - gomnd
+    - tenv
 
 run:
   timeout: 1m

--- a/charts/dashboard/README.md
+++ b/charts/dashboard/README.md
@@ -40,6 +40,11 @@ configure it through the `values.yaml` file.
 | ingress.labels | object | `{}` | Set any additional labels which should be added to the Ingress resource |
 | ingress.hosts | list | `[]` | Set the hostname and path mappings for this service on the Ingress |
 | ingress.tls | list | `[]` | Set the TLS secret and hostnames for this service on the Ingress |
+| httpRoute.create | bool | `false` | Set whether or not to create the HTTPRoute resource for the dashboard Service using the Gateway APIs |
+| httpRoute.parentRefs | list | `[]` | Set the parent references targeting the Gateways which will route traffic to this service |
+| httpRoute.hostnames | list | `[]` | Set the hostnames this HTTPRoute should respond to via the Gateways |
+| httpRoute.annotations | object | `{}` | Set any additional annotations which should be added to the HTTPRoute resource |
+| httpRoute.labels | object | `{}` | Set any additional labels which should be added to the HTTPRoute resource |
 | serviceAccount.create | bool | `false` | Set whether or not to create a ServiceAccount resource for the dashboard service |
 | serviceAccount.name | string | `nil` | Override the name of the ServiceAccount @default `.Chart.Name` |
 | serviceAccount.annotations | object | `{}` | Set any additional annotations which should be added to the ServiceAccount resource |

--- a/charts/dashboard/templates/http-route.yaml
+++ b/charts/dashboard/templates/http-route.yaml
@@ -1,0 +1,34 @@
+---
+{{- if .Values.httpRoute.create -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "dashboard.fullname" . }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{-   toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - kind: Service
+          name: {{ include "dashboard.fullname" . }}-frontend
+          port: {{ .Values.service.webPort }}
+{{- end }}

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -61,6 +61,25 @@ ingress:
   #    hosts:
   #      - dashboard.local
 
+httpRoute:
+  # -- Set whether or not to create the HTTPRoute resource for the dashboard
+  # Service using the Gateway APIs
+  create: false
+  # -- Set the parent references targeting the Gateways which will route traffic
+  # to this service
+  parentRefs: []
+  # - group: gateway.networking.k8s.io
+  #   kind: Gateway
+  #   namespace: example
+  #   name: default
+  # -- Set the hostnames this HTTPRoute should respond to via the Gateways
+  hostnames: []
+  # -- Set any additional annotations which should be added to the HTTPRoute
+  # resource
+  annotations: {}
+  # -- Set any additional labels which should be added to the HTTPRoute resource
+  labels: {}
+
 serviceAccount:
   # -- Set whether or not to create a ServiceAccount resource for the dashboard
   # service

--- a/internal/serve/metrics/main.go
+++ b/internal/serve/metrics/main.go
@@ -90,6 +90,7 @@ func NewService() *Service {
 func (s *Service) Start(e chan error) {
 	if s.server == nil {
 		s.health.Metrics = false
+		//nolint: loggercheck // The s.attr here points to an slog.Group
 		slog.Error(
 			"Failed to start metrics service",
 			slog.Group("error", slog.String("message", "service not configured")),
@@ -98,6 +99,7 @@ func (s *Service) Start(e chan error) {
 		e <- ErrServiceNotConfigured
 	}
 
+	//nolint: loggercheck // The s.attr here points to an slog.Group
 	slog.Info("Starting dashboard metrics service", s.attr)
 
 	s.health.Metrics = true
@@ -105,6 +107,7 @@ func (s *Service) Start(e chan error) {
 	err := s.server.ListenAndServe()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		s.health.Metrics = false
+		//nolint: loggercheck // The s.attr here points to an slog.Group
 		slog.Error(
 			"Failed to start metrics service",
 			slog.Group("error", slog.String("message", err.Error())),


### PR DESCRIPTION
As part of the general migration of `Ingress` to Gateway APIs, add support for creating an `HTTPRoute` resource which will attach this service to a Gateway API, if deployed and configured.

## Checklist

Before raising or requesting a review of the pull request, please check and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests locally to check
- [ ] I have added tests that prove that any changes are effective and work correctly
- [ ] I have made corresponding changes, as needed, to the repository documentation
- [x] Each commit in, and this pull request, have meaningful subjects and bodies for context
- [x] I have added `release/...`, `type/...`, and `changes/...` labels, as needed, to this pull request
